### PR TITLE
added support for Django 1.6 (only for Django-cms 3.x).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ env:
     - DJANGO=1.5 DJANGOCMS=2.4
     - DJANGO=1.4 DJANGOCMS=3
     - DJANGO=1.5 DJANGOCMS=3
+    - DJANGO=1.6 DJANGOCMS=3
 
 
 install:
     - pip install -q -r "test_requirements/django-$DJANGO.txt" --use-mirrors
     - if [ "${DJANGOCMS}" == "3" ]; then
-          pip install -q https://github.com/divio/django-cms/archive/3.0.0.beta2.tar.gz ;
+          pip install -q https://github.com/divio/django-cms/archive/develop.zip --no-deps ;
       else
           pip install -q django-cms==2.4 --use-mirrors ;
       fi

--- a/runtests.py
+++ b/runtests.py
@@ -13,6 +13,10 @@ def configure():
             os.path.dirname(os.path.realpath(__file__)), 'cmsplugin_googleplus', 'tests', 'example_project', x)
 
         test_settings = {
+            'LANGUAGE_CODE': 'en',
+            'LANGUAGES': (
+                ('en', 'English'),
+            ),
             'DATABASES': {
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',
@@ -34,7 +38,6 @@ def configure():
                 'cms.plugins.picture',
                 'cms.plugins.snippet',
                 'cms.plugins.teaser',
-                'djangocms_text_ckeditor',
                 'cms.plugins.video',
                 'cms',
                 'mptt',

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -3,7 +3,7 @@ django-nose>=1.2
 coverage>=3.7
 coveralls>=0.3
 
-google-api-python-client==1.2
+google-api-python-client>=1.2,<1.3
 python-dateutil>=2.1
 Pillow>=2.2.1
 django-classy-tags>=0.4
@@ -12,4 +12,3 @@ django-mptt>=0.6.0
 django-sekizai>=0.7
 argparse
 djangocms-admin-style
-djangocms-text-ckeditor>=2.0.2

--- a/test_requirements/django-1.4.txt
+++ b/test_requirements/django-1.4.txt
@@ -1,3 +1,3 @@
 -r base.txt
-Django>=1.4.9,<1.5
-django-reversion>=1.6.6,<1.7
+Django>=1.4,<1.5
+django-reversion>=1.6,<1.7

--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django>=1.6,<1.7
+django-reversion>=1.8,<1.9


### PR DESCRIPTION
- removed 'djangocms_text_ckeditor' not yet ready for Django 1.6
- updated requirements
- added LANGUAGE_CODE as fix for a failing test
